### PR TITLE
Removing deprecated prop types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "country-data": "0.0.31",
     "escape-string-regexp": "^1.0.5",
     "google-libphonenumber": "^2.0.10",
+    "prop-types": "^15.5.10",
     "react": "^15.4.2",
     "react-flag-kit": "0.2.2",
     "uuid": "^3.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import countries from 'country-data'
 import { AsYouTypeFormatter, PhoneNumberUtil, PhoneNumberFormat } from 'google-libphonenumber'
 import escapeStringRegexp from 'escape-string-regexp'


### PR DESCRIPTION
Removing deprecated PropTypes from React core and inserting from prop-types lib.
This ill stop to propagate warnings for proptypes usage from react core.